### PR TITLE
Loose required systemu version in gemspec

### DIFF
--- a/ruby-saml-for-portal.gemspec
+++ b/ruby-saml-for-portal.gemspec
@@ -58,14 +58,14 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<xmlcanonicalizer>, ["~> 0.1.2"])
       s.add_runtime_dependency(%q<uuid>, ["~> 2.3.7"])
-      s.add_runtime_dependency(%q<systemu>, ["~> 2.5.2"])
+      s.add_runtime_dependency(%q<systemu>, ["~> 2.5"])
       s.add_runtime_dependency(%q<rsa>, ["~> 0.1.4"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<mocha>, [">= 0"])
     else
       s.add_dependency(%q<xmlcanonicalizer>, ["~> 0.1.2"])
       s.add_dependency(%q<uuid>, ["~> 2.3.7"])
-      s.add_dependency(%q<systemu>, ["~> 2.5.2"])
+      s.add_dependency(%q<systemu>, ["~> 2.5"])
       s.add_dependency(%q<rsa>, ["~> 0.1.4"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<mocha>, [">= 0"])
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<xmlcanonicalizer>, ["~> 0.1.2"])
     s.add_dependency(%q<uuid>, ["~> 2.3.7"])
-    s.add_dependency(%q<systemu>, ["~> 2.5.2"])
+    s.add_dependency(%q<systemu>, ["~> 2.5"])
     s.add_dependency(%q<rsa>, ["~> 0.1.4"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<mocha>, [">= 0"])


### PR DESCRIPTION
This prevents application upgrade to recent versions of another gems:

```
Bundler could not find compatible versions for gem "systemu":
  In Gemfile:
    ruby-saml-for-portal (~> 0.4.0) was resolved to 0.4.2, which depends on
      uuid (~> 2.3.7) was resolved to 2.3.8, which depends on
        macaddr (~> 1.0) was resolved to 1.6.5, which depends on
          systemu (~> 2.6.2)

    ruby-saml-for-portal (~> 0.4.0) was resolved to 0.4.2, which depends on
      systemu (~> 2.5.2)
```
